### PR TITLE
Check existence of connect.session

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ function computeTransformFunctions(options) {
 
 module.exports = function(connect) {
   const Store = connect.Store || connect.session.Store
-  const MemoryStore = connect.MemoryStore || connect.session.MemoryStore
+  const MemoryStore = connect.MemoryStore || (connect.session && connect.session.MemoryStore)
 
   class MongoStore extends Store {
     constructor(options) {


### PR DESCRIPTION
Ensures the existence of connect.session before checking for connect.session.MemoryStore. This makes this more usable with session plugins that allow for use of express session stores.